### PR TITLE
Missing optimization assignment: Get Sibling node in a 1 indexed binary heap

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5074,13 +5074,13 @@ Instruction *cs6475_optimizer_suraj(Instruction *I) {
   cs6475_debug("And Expression Matched\n");
 
   cs6475_debug("Suraj: Optimization Possible\n");
-  auto bitwidth = A->getType()->getIntegerBitWidth();
-  auto one = APInt(bitwidth, 1);
+  auto Bitwidth = A->getType()->getIntegerBitWidth();
+  auto One = APInt(Bitwidth, 1);
 
   log_optzn("Suraj Yadav");
 
   auto *OptIns =
-      BinaryOperator::CreateXor(INPUT, ConstantInt::get(I->getContext(), one));
+      BinaryOperator::CreateXor(INPUT, ConstantInt::get(I->getContext(), One));
   return OptIns;
 }
 Instruction* cs6475_optimizer(Instruction *I) {
@@ -5106,7 +5106,12 @@ Instruction* cs6475_optimizer(Instruction *I) {
   // END JOHN REGEHR
 
   // BEGIN SURAJ YADAV
-  return cs6475_optimizer_suraj(I);
+  {
+    auto *NewI = cs6475_optimizer_suraj(I);
+    if (NewI != nullptr) {
+      return NewI;
+    }
+  }
   // END SURAJ YADAV
 
  return nullptr;

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5041,7 +5041,7 @@ void log_optzn(std::string Name) {
 void cs6475_debug(std::string DbgString) {
   // set this to "false" to suppress debug output, before running "ninja test"
   // set this to "true" to see debug output, to help you understand your transformation
-  if (true)
+  if (false)
     dbgs() << DbgString;
 }
 
@@ -5066,6 +5066,10 @@ Instruction* cs6475_optimizer(Instruction *I) {
     }
   }
   // END JOHN REGEHR
+
+  // BEGIN SURAJ YADAV
+
+  // END SURAJ YADAV
 
  return nullptr;
 }

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5077,6 +5077,8 @@ Instruction *cs6475_optimizer_suraj(Instruction *I) {
   auto bitwidth = A->getType()->getIntegerBitWidth();
   auto one = APInt(bitwidth, 1);
 
+  log_optzn("Suraj Yadav");
+
   auto *OptIns =
       BinaryOperator::CreateXor(INPUT, ConstantInt::get(I->getContext(), one));
   return OptIns;

--- a/llvm/test/Transforms/InstCombine/binary-heap-sibling-node-to-xor.ll
+++ b/llvm/test/Transforms/InstCombine/binary-heap-sibling-node-to-xor.ll
@@ -1,0 +1,52 @@
+; RUN: opt -O2 -S < %s | FileCheck %s
+
+; Positive Tests
+define i4 @sibling-node-i4(i4 %0) {
+; CHECK-LABEL: @sibling-node-i4(
+; CHECK:       [[d:%.+]] = xor i4 %0, 1
+; CHECK-NEXT:  ret i4 [[d]]
+;
+  %a = urem i4 %0, 2
+  %b = icmp eq i4 %a, 1
+  br i1 %b, label %right,label %left
+  left:
+  %c = add i4 %0, 1
+  ret i4 %c
+  right:
+  %d = sub i4 %0, 1
+  ret i4 %d
+}
+
+
+define i16 @sibling-node-i16(i16 %0) {
+; CHECK-LABEL: @sibling-node-i16(
+; CHECK:       [[d:%.+]] = xor i16 %0, 1
+; CHECK-NEXT:  ret i16 [[d]]
+;
+  %a = and i16 %0, 1
+  %b = icmp eq i16 %a, 0
+  %c = select i1 %b, i16 1, i16 -1
+  %d = add i16 %c, %0
+  ret i16 %d
+}
+
+
+; Negative Tests
+define i8 @sibling-node-i8-fail(i8 %0) {
+; CHECK-LABEL: @sibling-node-i8-fail(
+; CHECK:      [[a:%.+]] = and i8 %0, 1
+; CHECK-NEXT: [[b:%.+]] = icmp eq i8 [[a]], 0
+; CHECK-NEXT: [[c:%.+]] = select i1 [[b]], i8 -1, i8 1
+; CHECK-NEXT: [[d:%.+]] = add i8 [[c]], %0
+; CHECK-NEXT: ret i8 [[d]]
+;
+  %a = urem i8 %0, 2
+  %b = icmp eq i8 %a, 1
+  br i1 %b, label %right,label %left
+  left:
+  %c = sub i8 %0, 1
+  ret i8 %c
+  right:
+  %d = add i8 %0, 1
+  ret i8 %d
+}

--- a/src.ll
+++ b/src.ll
@@ -1,5 +1,0 @@
-define i16 @opt13(i16 %x) {
-  %a = sub i16 32767, %x
-  %b = and i16 %x, %a
-  ret i16 %b
-}

--- a/src.ll
+++ b/src.ll
@@ -1,0 +1,5 @@
+define i16 @opt13(i16 %x) {
+  %a = sub i16 32767, %x
+  %b = and i16 %x, %a
+  ret i16 %b
+}


### PR DESCRIPTION
Current LLVM state (misses this optimization)
https://gcc.godbolt.org/z/baa4ddTex

Refinement Proof
https://alive2.llvm.org/ce/z/-pnJgd

Running `ninja -t check` on this branch increases number of passing test case by 1.
Test case also verified by running directly

```
❯ ./build/bin/llvm-lit -v ./llvm/test/Transforms/InstCombine/binary-heap-sibling-node-to-xor.ll
-- Testing: 1 tests, 1 workers --
PASS: LLVM :: Transforms/InstCombine/binary-heap-sibling-node-to-xor.ll (1 of 1)

Testing Time: 0.05s

Total Discovered Tests: 1
  Passed: 1 (100.00%)
```

```diff
-❯ ninja -t check on cs6475-assignment2
+❯ ninja -t check on cs6475-assignment2-suraj
 ********************
 Failed Tests (4):
   Clang :: Driver/cross-linux.c
   Clang :: Driver/cuda-detect-path.cu
   Clang :: Headers/opencl-c-header.cl
   Clang :: LibClang/symbols.test
 
 
-Testing Time: 365.54s
+Testing Time: 370.90s
 
-Total Discovered Tests: 99572
+Total Discovered Tests: 99573
   Skipped          :   357 (0.36%)
   Unsupported      : 32172 (32.31%)
-  Passed           : 66949 (67.24%)
+  Passed           : 66950 (67.24%)
   Expectedly Failed:    90 (0.09%)
   Failed           :     4 (0.00%)
```