### PR TITLE
Kincaid Savoie - assignment 2

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -57,7 +57,6 @@
 #include "llvm/Analysis/Utils/Local.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/Analysis/VectorUtils.h"
-#include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/CFG.h"
 #include "llvm/IR/Constant.h"
@@ -5042,7 +5041,7 @@ void log_optzn(std::string Name) {
 void cs6475_debug(std::string DbgString) {
   // set this to "false" to suppress debug output, before running "ninja test"
   // set this to "true" to see debug output, to help you understand your transformation
-  if (false)
+  if (true)
     dbgs() << DbgString;
 }
 

--- a/llvm/test/Transforms/InstCombine/ksavoie-assignment-2.ll
+++ b/llvm/test/Transforms/InstCombine/ksavoie-assignment-2.ll
@@ -1,0 +1,37 @@
+; RUN: opt < %s -passes='instcombine<no-verify-fixpoint>' -S | FileCheck %s
+
+define noundef i32 @reduce-case(i32 noundef %x, i32 noundef %y) unnamed_addr #0 {
+; CHECK-LABEL: @reduce-case(
+; CHECK-NEXT:    [[A:%.*]] = and i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[B:%.*]] = xor i32 [[A:%.*]], -1
+; CHECK-NEXT:    [[C:%.*]] = and i32 [[B:%.*]], [[X:%.*]]
+; CHECK-NEXT:    ret i32 [[C:%.*]]
+
+  %1 = and i32 %x, 1
+  %2 = xor i32 %y, -1
+  %3 = and i32 %1, %2
+  %4 = and i32 %x, -2
+  %5 = or disjoint i32 %3, %4 
+
+  ret i32 %5
+}
+
+define noundef i32 @reduce-case-fail-diff-const(i32 noundef %x, i32 noundef %y) unnamed_addr #0 {
+; CHECK-LABEL: @reduce-case-fail-diff-const(
+; CHECK-NEXT:    [[A:%.*]] = and i32 [[X:%.*]], 255
+; CHECK-NEXT:    [[B:%.*]] = xor i32 [[Y:%.*]], -1
+; CHECK-NEXT:    [[C:%.*]] = and i32 [[A:%.*]], [[B:%.*]]
+; CHECK-NEXT:    [[D:%.*]] = and i32 [[X:%.*]], -2
+; CHECK-NEXT:    [[E:%.*]] = or disjoint i32 [[C:%.*]], [[D:%.*]] 
+; CHECK-NEXT:    ret i32 [[E:%.*]]
+
+  %1 = and i32 %x, 255
+  %2 = xor i32 %y, -1
+  %3 = and i32 %1, %2
+  %4 = and i32 %x, -2
+  %5 = or disjoint i32 %3, %4 
+
+  ret i32 %5
+}
+
+attributes #0 = { mustprogress nofree norecurse nosync nounwind nonlazybind willreturn memory(none) uwtable "probe-stack"="inline-asm" "target-cpu"="x86-64" }


### PR DESCRIPTION
Implement the optimization described in this Github issue: https://github.com/llvm/llvm-project/issues/83699

Here is the refinement:
```
define noundef i32 @src(i32 noundef %prev_value, i32 noundef %new_value) unnamed_addr {
start:
  %0 = and i32 %prev_value, 1
  %new_bit = and i32 %new_value, 1
  %_5 = xor i32 %new_bit, -1
  %1 = and i32 %0, %_5
  %_6 = and i32 %prev_value, -2
  %_0 = or disjoint i32 %1, %_6
  ret i32 %_0
}

define noundef i32 @tgt(i32 noundef %prev_value, i32 noundef %new_value) unnamed_addr {
start:
  %_4 = and i32 %new_value, 1
  %_3 = xor i32 %_4, -1
  %_0 = and i32 %_3, %prev_value
  ret i32 %_0
}
```

Here is a link to compiler explorer showing that the optimization hasn't been implemented: https://godbolt.org/z/ofnfGrYx5

And an Alive2 link showing that the transformation is a refinement: https://alive2.llvm.org/ce/z/GQeQTS

A positive and negative test have been added in `test/Transforms/InstCombine/ksavoie-assignment-2.ll`