### PR TITLE
Remove unnecessary `icmp` after an `or` followed by `add`

### DIFF
--- a/llvm/test/Transforms/InstCombine/dominic_kennedy_remove_add_or.ll
+++ b/llvm/test/Transforms/InstCombine/dominic_kennedy_remove_add_or.ll
@@ -5,9 +5,9 @@ define i1 @test1(i8 %0) {
 ; CHECK-LABEL: @test1(
 ; CHECK-NEXT:    ret i1 false
 ;
-  %2 = or i8 %0, 55
-  %3 = add i8 %2, 126
-  %4 = icmp ult i8 %3, 53
+  %2 = or i8 %0, 32
+  %3 = add i8 %2, -65
+  %4 = icmp ult i8 %3, 31
   ret i1 %4
 }
 
@@ -16,8 +16,8 @@ define i1 @test2(i8 %0) {
 ; CHECK-LABEL: @test2(
 ; CHECK-NOT:    ret i1 false
 ;
-  %2 = or i8 %0, 55
-  %3 = add i8 %2, 126
-  %4 = icmp ult i8 %3, 54
+  %2 = or i8 %0, 32
+  %3 = add i8 %2, -65
+  %4 = icmp ult i8 %3, 32
   ret i1 %4
 }

--- a/llvm/test/Transforms/InstCombine/dominic_kennedy_remove_add_or.ll
+++ b/llvm/test/Transforms/InstCombine/dominic_kennedy_remove_add_or.ll
@@ -1,0 +1,23 @@
+; RUN: opt < %s -passes=instcombine -S | FileCheck %s
+
+; positive test
+define i1 @test1(i8 %0) {
+; CHECK-LABEL: @test1(
+; CHECK-NEXT:    ret i1 false
+;
+  %2 = or i8 %0, 55
+  %3 = add i8 %2, 126
+  %4 = icmp ult i8 %3, 53
+  ret i1 %4
+}
+
+; negative test
+define i1 @test2(i8 %0) {
+; CHECK-LABEL: @test2(
+; CHECK-NOT:    ret i1 false
+;
+  %2 = or i8 %0, 55
+  %3 = add i8 %2, 126
+  %4 = icmp ult i8 %3, 54
+  ret i1 %4
+}


### PR DESCRIPTION
Optimization is a generalization of [this](https://github.com/llvm/llvm-project/issues/96519) issue
[Proof](https://gcc.godbolt.org/z/rfrTTohd1) of missed optimization
[TV](https://alive2.llvm.org/ce/z/6kc-_T) of optimization

Test suite before optimization:
```
Total Discovered Tests: 99707
  Skipped          :    19 (0.02%)
  Unsupported      :  1210 (1.21%)
  Passed           : 98268 (98.56%)
  Expectedly Failed:   196 (0.20%)
  Failed           :    14 (0.01%)
```

Test suite after optimization:
```
Total Discovered Tests: 99708
  Skipped          :    19 (0.02%)
  Unsupported      :  1210 (1.21%)
  Passed           : 98269 (98.56%)
  Expectedly Failed:   196 (0.20%)
  Failed           :    14 (0.01%)
```

