### PR TITLE
Optimize domain of x*x being positive for floats

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5076,7 +5076,6 @@ Instruction* cs6475_optimizer(Instruction *I) {
   CmpInst::Predicate Pred;
   Value *X1 = nullptr;
   Value *X2 = nullptr;
-  Value *LiteralTrue = ConstantInt::getTrue(I->getContext());
 
   if (match(I,
             m_FCmp(Pred, m_FAdd(m_FMul(m_Value(X1), m_Value(X2)),
@@ -5145,6 +5144,7 @@ Instruction* cs6475_optimizer(Instruction *I) {
         }
         // In this case, we know that the condition will always return
         // false, even if x is Nan.
+        Value *LiteralTrue = ConstantInt::getTrue(I->getContext());
         return new ICmpInst(ICmpInst::ICMP_NE, LiteralTrue, LiteralTrue);
       }
     }

--- a/llvm/test/Transforms/InstCombine/square_positive.ll
+++ b/llvm/test/Transforms/InstCombine/square_positive.ll
@@ -1,0 +1,41 @@
+; RUN: opt < %s -passes=instcombine -S | FileCheck %s
+
+; positive tests
+; x * x + c1 > c2 where c1 > c2 => isnan(x)
+define i32 @t1(float %x) {
+    %1 = fmul float %x, %x
+    %2 = fadd float %1, 77.0e+00
+    %3 = fcmp ogt float %2, 22.0e+00
+    %4 = select i1 %3, i32 1, i32 2
+    ret i32 %4
+    ; CHECK-LABEL: @t1(
+    ; CHECK: [[r1:%.*]] = fcmp ord float %x, 0.000000e+00
+    ; CHECK-NEXT: [[r2:%.*]] = select i1 [[r1]], i32 1, i32 2 
+    ; CHECK-NEXT: ret i32 [[r2]]
+}
+
+; x * x + c1 < c2 where c1 > c2 => false
+define i32 @t2(float %x) {
+    %1 = fmul float %x, %x
+    %2 = fadd float %1, 77.0e+00
+    %3 = fcmp olt float %2, 22.0e+00
+    %4 = select i1 %3, i32 1, i32 2
+    ret i32 %4
+    ; CHECK-LABEL: @t2(
+    ; CHECK-NEXT: ret i32 2
+}
+
+; negative test
+; x * x + c1 > c2 where c1 < c2 => no optimization
+define i32 @t3(float %x) {
+    %1 = fmul float %x, %x
+    %2 = fadd float %1, 22.0e+00
+    %3 = fcmp ogt float %2, 77.0e+00
+    %4 = select i1 %3, i32 1, i32 2
+    ret i32 %4
+    ; CHECK-LABEL: @t3(
+    ; CHECK-NOT:  [[r0:%.*]] = fcmp ord float %x, 0.000000e+00
+    ; CHECK:      [[r1:%.*]] = fcmp ogt float %2, 7.700000e+01
+    ; CHECK-NEXT: [[r2:%.*]] = select i1 [[r1]], i32 1, i32 2 
+    ; CHECK-NEXT: ret i32 [[r2]]
+}


### PR DESCRIPTION
## Summary of optimization

Rationale: `x*x` should always be positive for floating numbers. Exploit this when adding a constant and comparing against another constant.

`x` is a float, `c1` and `c2` are constants.

 - `x*x + c1 > c2` ⇒ `is_nan(x)` if `c1 > c2`
 - `x*x + c1 ≥ c2` ⇒ `is_nan(x)` if `c1 ≥ c2`
 - `x*x + c1 < c2` ⇒ `false` if `c1 ≥ c2`
 - `x*x + c1 ≤ c2` ⇒ `false` if `c1 > c2`

## Testing

<details>
<summary>Test output before optimization</summary>
<pre>
Total Discovered Tests: 99588
  Skipped          :  8124 (8.16%)
  Unsupported      : 36306 (36.46%)
  Passed           : 55090 (55.32%)
  Expectedly Failed:    65 (0.07%)
  Failed           :     3 (0.00%)
</pre>
</details>
<details>
<summary>Test output after optimization</summary>
<pre>
Total Discovered Tests: 99589
  Skipped          :  8124 (8.16%)
  Unsupported      : 36306 (36.46%)
  Passed           : 55091 (55.32%)
  Expectedly Failed:    65 (0.07%)
  Failed           :     3 (0.00%)
</pre>
</details>