### PR TITLE
Add optimization for MaxSignedValue - (x ⊕ c) transformation

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5046,7 +5046,7 @@ void cs6475_debug(std::string DbgString) {
 }
 
 // BEGIN YEASEEN ARAFAT
-static Instruction* cs6745_yeaseen_opt(Instruction* I){
+static Instruction* cs6475_yeaseen_opt(Instruction* I){
   //0x7FFFFFFF - (x ⊕ c) → x ⊕ (0x7FFFFFFF - c)
   ConstantInt *C1 = nullptr;
   ConstantInt *C2 = nullptr;
@@ -5213,7 +5213,7 @@ bool InstCombinerImpl::run() {
     LLVM_DEBUG(dbgs() << "IC: Visiting: " << OrigI << '\n');
 
     Instruction *Result = nullptr;
-    if ((Result = visit(*I)) || (Result = cs6475_optimizer(I)) || (Result = cs6745_yeaseen_opt(I))) {
+    if ((Result = visit(*I)) || (Result = cs6475_optimizer(I)) || (Result = cs6475_yeaseen_opt(I))) {
       ++NumCombined;
       // Should we replace the old instruction with a new one?
       if (Result != I) {

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5045,6 +5045,15 @@ void cs6475_debug(std::string DbgString) {
     dbgs() << DbgString;
 }
 
+// BEGIN YEASEEN ARAFAT
+static Instruction* yeaseen_opt(Instruction* I){
+  //0x7FFFFFFF - (x ⊕ c) → x ⊕ (0x7FFFFFFF - c)
+
+  cs6475_debug("YA:TESTING");
+  return I;
+}
+//END YEASEEN ARAFAT
+
 Instruction* cs6475_optimizer(Instruction *I) {
   cs6475_debug("\nCS 6475 matcher: running now\n");
 
@@ -5066,6 +5075,10 @@ Instruction* cs6475_optimizer(Instruction *I) {
     }
   }
   // END JOHN REGEHR
+
+  // BEGIN YEASEEN ARAFAT
+  
+  // END YEASEEN ARFAT
 
  return nullptr;
 }

--- a/llvm/test/Transforms/InstCombine/max_signed_value_xor.ll
+++ b/llvm/test/Transforms/InstCombine/max_signed_value_xor.ll
@@ -1,16 +1,56 @@
-; RUN: opt -instcombine -S < %s | FileCheck %s
+; RUN: opt -O2 -S < %s | FileCheck %s
 
 ; This is a positive test case checking that the optimization of the form
-; MaxSignedValue - (x ⊕ c) → x ⊕ (MaxSignedValue - c) is correctly applied
+; MaxSignedValue - (x ⊕ c) → x ⊕ (MaxSignedValue - c) is correctly applied for 8-bit integers
+
+define i8 @opt8(i8 %x) {
+  ; CHECK-LABEL: @opt8(
+  ; CHECK-NEXT: %b = xor i8 %x, 77
+  ; CHECK-NEXT: ret i8 %b
+  %a = xor i8 %x, 50
+  %b = sub i8 127, %a           ; MaxSignedValue for 8-bit is 127
+  ret i8 %b
+}
+
+
+; This is a positive test case checking that the optimization of the form
+; MaxSignedValue - (x ⊕ c) → x ⊕ (MaxSignedValue - c) is correctly applied for 16-bit integers
 
 define i16 @opt16(i16 %x) {
   ; CHECK-LABEL: @opt16(
   ; CHECK-NEXT: %b = xor i16 %x, 29434
   ; CHECK-NEXT: ret i16 %b
   %a = xor i16 %x, 3333
-  %b = sub i16 32767, %a
+  %b = sub i16 32767, %a        ; MaxSignedValue for 16-bit is 32767
   ret i16 %b
 }
+
+
+; This is a positive test case checking that the optimization of the form
+; MaxSignedValue - (x ⊕ c) → x ⊕ (MaxSignedValue - c) is correctly applied for 32-bit integers
+
+define i32 @opt32(i32 %x) {
+  ; CHECK-LABEL: @opt32(
+  ; CHECK-NEXT: %b = xor i32 %x, 2147433647
+  ; CHECK-NEXT: ret i32 %b
+  %a = xor i32 %x, 50000
+  %b = sub i32 2147483647, %a    ; MaxSignedValue for 32-bit is 2147483647
+  ret i32 %b
+}
+
+
+; This is a positive test case checking that the optimization of the form
+; MaxSignedValue - (x ⊕ c) → x ⊕ (MaxSignedValue - c) is correctly applied for 64-bit integers
+
+define i64 @opt64(i64 %x) {
+  ; CHECK-LABEL: @opt64(
+  ; CHECK-NEXT: %b = xor i64 %x, 9223372036849775807
+  ; CHECK-NEXT: ret i64 %b
+  %a = xor i64 %x, 5000000
+  %b = sub i64 9223372036854775807, %a    ; MaxSignedValue for 64-bit is 9223372036854775807
+  ret i64 %b
+}
+
 
 ; This is a negative test case where the optimization should NOT be applied
 ; because 20000 is not the max signed value for i16 (32767).
@@ -20,6 +60,6 @@ define i16 @neg_opt16(i16 %x) {
   ; CHECK-NOT: %b = xor
   ; CHECK: %b = sub i16 20000, %a
   %a = xor i16 %x, 3333
-  %b = sub i16 20000, %a
+  %b = sub i16 20000, %a   
   ret i16 %b
 }

--- a/llvm/test/Transforms/InstCombine/max_signed_value_xor.ll
+++ b/llvm/test/Transforms/InstCombine/max_signed_value_xor.ll
@@ -1,0 +1,25 @@
+; RUN: opt -instcombine -S < %s | FileCheck %s
+
+; This is a positive test case checking that the optimization of the form
+; MaxSignedValue - (x ⊕ c) → x ⊕ (MaxSignedValue - c) is correctly applied
+
+define i16 @opt16(i16 %x) {
+  ; CHECK-LABEL: @opt16(
+  ; CHECK-NEXT: %b = xor i16 %x, 29434
+  ; CHECK-NEXT: ret i16 %b
+  %a = xor i16 %x, 3333
+  %b = sub i16 32767, %a
+  ret i16 %b
+}
+
+; This is a negative test case where the optimization should NOT be applied
+; because 20000 is not the max signed value for i16 (32767).
+
+define i16 @neg_opt16(i16 %x) {
+  ; CHECK-LABEL: @neg_opt16(
+  ; CHECK-NOT: %b = xor
+  ; CHECK: %b = sub i16 20000, %a
+  %a = xor i16 %x, 3333
+  %b = sub i16 20000, %a
+  ret i16 %b
+}


### PR DESCRIPTION
## Summary

- This PR adds an optimization for transforming MaxSignedValue - (x ⊕ c) into x ⊕ (MaxSignedValue - c).
- Positive test cases for 8-bit, 16-bit, 32-bit, and 64-bit integers and one negative test case are included in `max_signed_value_xor.ll` test file.