### PR TITLE
Missing optimization for `(X+1)**2 - (X**2+2X+1)` 

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5041,7 +5041,7 @@ void log_optzn(std::string Name) {
 void cs6475_debug(std::string DbgString) {
   // set this to "false" to suppress debug output, before running "ninja test"
   // set this to "true" to see debug output, to help you understand your transformation
-  if (true)
+  if (false)
     dbgs() << DbgString;
 }
 
@@ -5069,7 +5069,16 @@ Instruction* cs6475_optimizer(Instruction *I) {
 
  return nullptr;
 }
-
+/*
+The optimization is based on (x+1)**2 - (x**2 - 2*x + 1) --> 0
+The compiler using 
+-O2 - on the source IR changes it to IR which contains an XOR instruction
+This optimization is done somewhere in the O2 pipeline.
+I started with the input IR without the XOR instruction but later found that the code was doing something funky, 
+So I went on to use the optimized IR as input to my pass, so the IR with XOR instruction is the input to my pass.
+I could have changed it to the old style but just skipped as I would have to again rewrite the pass and that would 
+have failed if 02 was applied.
+ */
 Instruction *cs6475_sameeran(Instruction *I) {
     cs6475_debug("\nCS 6475 Sameeran: running now\n");
 
@@ -5103,6 +5112,7 @@ Instruction *cs6475_sameeran(Instruction *I) {
 
                         I->replaceAllUsesWith(cintzero);
                         cs6475_debug("Sam: Applied optimization\n");
+                        log_optzn("Sameeran");
 
                         return I;
                     }

--- a/llvm/test/Transforms/InstCombine/return_expression.ll
+++ b/llvm/test/Transforms/InstCombine/return_expression.ll
@@ -1,0 +1,13 @@
+; RUN: opt < %s -passes=instcombine -S | FileCheck %s
+
+; CHECK-LABEL: @workedfinally(
+; CHECK: ret i16 0
+define i16 @workedfinally(i16 %x) {
+  %x_plus_1 = add i16 %x, 1
+  %x_plus_1_sq = mul i16 %x_plus_1, %x_plus_1
+  %two_x1 = add i16 %x, 2
+  %temp = mul i16 %two_x1, %x
+  %B.neg = xor i16 %temp, -1
+  %final = add i16 %x_plus_1_sq, %B.neg
+  ret i16 %final
+}

--- a/llvm/test/Transforms/InstCombine/return_expression2.ll
+++ b/llvm/test/Transforms/InstCombine/return_expression2.ll
@@ -1,0 +1,14 @@
+; RUN: opt < %s -passes=instcombine -S | FileCheck %s
+
+; CHECK-LABEL: @workedfinally(
+; CHECK: ret i16 0
+define i16 @workedfinally(i16 %x) {
+  %x_plus_1 = add i16 %x, 1
+  %x_plus_1_sq = mul i16 %x_plus_1, %x_plus_1
+  %two_x1 = add i16 %x, 2
+  %temp = mul i16 %two_x1, %x
+  %B.neg = xor i16 %temp, -1
+  %final = add i16 %x_plus_1_sq, %B.neg
+  %addition = add i16 %final, %final  ; Addition of final with final still should be 0
+  ret i16 %addition
+}

--- a/llvm/test/Transforms/InstCombine/return_expression3.ll
+++ b/llvm/test/Transforms/InstCombine/return_expression3.ll
@@ -1,0 +1,15 @@
+; RUN: opt < %s -passes=instcombine -S | FileCheck %s
+
+; CHECK-LABEL: @workedfinally(
+; CHECK: ret i16 %x
+define i16 @workedfinally(i16 %x) {
+  %x_plus_1 = add i16 %x, 1
+  %x_plus_1_sq = mul i16 %x_plus_1, %x_plus_1
+  %two_x1 = add i16 %x, 2
+  %temp = mul i16 %two_x1, %x
+  %B.neg = xor i16 %temp, -1
+  %final = add i16 %x_plus_1_sq, %B.neg
+  %addition = add i16 %final, %x  ; Addition of final with final still should be 0
+
+  ret i16 %addition
+}

--- a/llvm/test/Transforms/InstCombine/return_expression4.ll
+++ b/llvm/test/Transforms/InstCombine/return_expression4.ll
@@ -1,0 +1,14 @@
+; RUN: opt < %s -passes=instcombine -S | FileCheck %s
+
+; CHECK-LABEL: @workedfinally(
+; CHECK-not: ret i16 %x
+define i16 @workedfinally(i16 %x) {
+  %x_plus_1 = add i16 %x, 2 ; Changed 1 to 2, should not match
+  %x_plus_1_sq = mul i16 %x_plus_1, %x_plus_1
+  %two_x1 = add i16 %x, 2
+  %temp = mul i16 %two_x1, %x
+  %B.neg = xor i16 %temp, -1
+  %final = add i16 %x_plus_1_sq, %B.neg
+  
+  ret i16 %final
+}


### PR DESCRIPTION
The optimization for equation should always 
`(X+1)**2 - (X**2+2X+1)` --> `ret 0`

1. [LLVM Opt.](https://gcc.godbolt.org/z/qbcxY6Pbc)

2. [ALIVE2](https://alive2.llvm.org/ce/z/jNdBED)