### PR TITLE
Zeyuan assignment2

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -94,7 +94,6 @@
 #include "llvm/Support/KnownBits.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/InstCombine/InstCombine.h"
-#include "llvm/Transforms/InstCombine/InstCombiner.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Transforms/Utils/Local.h"
 #include <algorithm>
@@ -5042,7 +5041,7 @@ void log_optzn(std::string Name) {
 void cs6475_debug(std::string DbgString) {
   // set this to "false" to suppress debug output, before running "ninja test"
   // set this to "true" to see debug output, to help you understand your transformation
-  if (false)
+  if (true)
     dbgs() << DbgString;
 }
 
@@ -5062,8 +5061,6 @@ Instruction* cs6475_optimizer(Instruction *I) {
 	log_optzn("John Regehr");
 	auto SMin = APInt::getSignedMinValue(C->getUniqueInteger().getBitWidth());
 	Instruction *NewI = BinaryOperator::CreateAnd(X, ConstantInt::get(I->getContext(), SMin));
-  NewI->print(dbgs());
-  cs6475_debug("\n");
 	return NewI;
       }
     }

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -94,6 +94,7 @@
 #include "llvm/Support/KnownBits.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/InstCombine/InstCombine.h"
+#include "llvm/Transforms/InstCombine/InstCombiner.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Transforms/Utils/Local.h"
 #include <algorithm>
@@ -5041,7 +5042,7 @@ void log_optzn(std::string Name) {
 void cs6475_debug(std::string DbgString) {
   // set this to "false" to suppress debug output, before running "ninja test"
   // set this to "true" to see debug output, to help you understand your transformation
-  if (true)
+  if (false)
     dbgs() << DbgString;
 }
 
@@ -5061,11 +5062,69 @@ Instruction* cs6475_optimizer(Instruction *I) {
 	log_optzn("John Regehr");
 	auto SMin = APInt::getSignedMinValue(C->getUniqueInteger().getBitWidth());
 	Instruction *NewI = BinaryOperator::CreateAnd(X, ConstantInt::get(I->getContext(), SMin));
+  NewI->print(dbgs());
+  cs6475_debug("\n");
 	return NewI;
       }
     }
   }
   // END JOHN REGEHR
+
+  //BEGIN ZEYUAN WANG
+  // x*(x+2) + 1 -> (x+1)*(x+1)
+  Value *X1 = nullptr;
+  Value *Y1 = nullptr;
+  cs6475_debug("ZYW: begin\n");
+  if(match(I,m_Add(m_Value(X1), m_Value(Y1)))){
+    cs6475_debug("ZYW: matched the first 'add'\n");
+    ConstantInt* C1 = nullptr;
+    ConstantInt* C2 = nullptr;
+    Value* X2 = nullptr;
+    Value* X3 = nullptr;
+    Value* X4 = nullptr;
+    Value* X5 = nullptr;
+    if (match(Y1,m_ConstantInt(C1))&& C1->equalsInt(1)) {
+      cs6475_debug("ZYW: matched the constant '1' at Y1\n");
+      if(match(X1,m_Mul(m_Value(X2), m_Value(X3))))
+      {
+        cs6475_debug("ZYW: matched the 'mul'\n");
+        if(match(X3,m_Add(m_Value(X4), m_Value(X5))))
+        {
+          cs6475_debug("ZYW: matched the second 'add'\n");
+          if(match(X5,m_ConstantInt(C2)) && C2->equalsInt(2))
+          {
+            cs6475_debug("ZYW: matched the constant '2'\n");
+            if(match(X2,m_Specific(X4)))
+            {
+              cs6475_debug("ZYW: matched the specific 'x'\n");
+              Instruction* NewAdd = BinaryOperator::CreateAdd(X4, C1);
+              NewAdd->insertBefore(I);
+              Instruction* NewMul =  BinaryOperator::CreateMul(NewAdd,NewAdd);
+              cs6475_debug("ZYW: new instructions created\n");
+              return NewMul;
+            }
+          }
+        }else if(match(X2,m_Add(m_Value(X4), m_Value(X5))))
+        {
+          cs6475_debug("ZYW: matched the second 'add'\n");
+          if(match(X5,m_ConstantInt(C2)) && C2->equalsInt(2))
+          {
+            cs6475_debug("ZYW: matched the constant '2'\n");
+            if(match(X3,m_Specific(X4)))
+            {
+              cs6475_debug("ZYW: matched the specific 'x'\n");
+              Instruction* NewAdd = BinaryOperator::CreateAdd(X4, C1);
+              NewAdd->insertBefore(I);
+              Instruction* NewMul =  BinaryOperator::CreateMul(NewAdd,NewAdd);
+              cs6475_debug("ZYW: new instructions created\n");
+              return NewMul;
+            }
+          }
+        }
+      }
+    }
+  }
+  //END ZEYUAN WANG
 
  return nullptr;
 }

--- a/llvm/test/Transforms/InstCombine/perfect_square_trinomial_const.ll
+++ b/llvm/test/Transforms/InstCombine/perfect_square_trinomial_const.ll
@@ -1,0 +1,108 @@
+; RUN: opt < %s -O2 -S | FileCheck %s
+
+; positive tests
+
+define i16 @test1(i16 %x) {
+        %tmp1 = mul i16 %x, %x
+        %tmp2 = mul i16 %x, 2
+        %tmp3 = add i16 %tmp1, %tmp2
+        %tmp4 = add i16 %tmp3, 1
+        ret i16 %tmp4
+; CHECK-LABEL: @test1(
+; CHECK-NEXT: add i16 %x, 1
+; CHECK-NEXT: mul i16 %1, %1
+; CHECK-NEXT: ret i16
+}
+
+define i32 @test2(i32 %x) {
+        %tmp1 = mul i32 %x, %x
+        %tmp2 = mul i32 %x, 2
+        %tmp3 = add i32 %tmp1, %tmp2
+        %tmp4 = add i32 %tmp3, 1
+        ret i32 %tmp4
+; CHECK-LABEL: @test2(
+; CHECK-NEXT: add i32 %x, 1
+; CHECK-NEXT: mul i32 %1, %1
+; CHECK-NEXT: ret i32
+}
+
+define i64 @test3(i64 %x) {
+        %tmp1 = mul i64 %x, %x
+        %tmp2 = mul i64 %x, 2
+        %tmp3 = add i64 %tmp1, %tmp2
+        %tmp4 = add i64 %tmp3, 1
+        ret i64 %tmp4
+; CHECK-LABEL: @test3(
+; CHECK-NEXT: add i64 %x, 1
+; CHECK-NEXT: mul i64 %1, %1
+; CHECK-NEXT: ret i64
+}
+
+; replace mul x, 2 with shl x, 1
+define i64 @test4(i64 %x) {
+        %tmp1 = mul i64 %x, %x
+        %tmp2 = shl i64 %x, 1
+        %tmp3 = add i64 %tmp1, %tmp2
+        %tmp4 = add i64 %tmp3, 1
+        ret i64 %tmp4
+; CHECK-LABEL: @test4(
+; CHECK-NEXT: add i64 %x, 1
+; CHECK-NEXT: mul i64 %1, %1
+; CHECK-NEXT: ret i64
+}
+
+; exchange order of terms
+define i32 @test6(i32 %x) {
+        %tmp1 = mul i32 %x, %x
+        %tmp2 = add i32 %tmp1, 1
+        %tmp3 = shl i32 %x, 1
+        %tmp4 = add i32 %tmp2, %tmp3
+        ret i32 %tmp4
+; CHECK-LABEL: @test6(
+; CHECK-NEXT: add i32 %x, 1
+; CHECK-NEXT: mul i32 %1, %1
+; CHECK-NEXT: ret i32 
+}
+
+; negative tests
+
+define i16 @test7(i16 %x) {
+        %tmp1 = mul i16 %x, %x
+        %tmp2 = mul i16 %x, 2
+        %tmp3 = add i16 %tmp1, %tmp2
+        %tmp4 = add i16 %tmp3, 2
+        ret i16 %tmp4
+; CHECK-LABEL: @test7(
+; CHECK-NEXT: add i16 %x, 2
+; CHECK-NEXT: mul i16 %tmp21, %x
+; CHECK-NEXT: add i16 %tmp3, 2
+; CHECK-NEXT: ret i16
+}
+
+define i32 @test8(i32 %x) {
+        %tmp1 = mul i32 %x, %x
+        %tmp2 = mul i32 %x, 3
+        %tmp3 = add i32 %tmp1, %tmp2
+        %tmp4 = add i32 %tmp3, 1
+        ret i32 %tmp4
+; CHECK-LABEL: @test8(
+; CHECK-NEXT: add i32 %x, 3
+; CHECK-NEXT: mul i32 %tmp21, %x
+; CHECK-NEXT: add i32 %tmp3, 1
+; CHECK-NEXT: ret i32
+}
+
+define i64 @test9(i64 %x) {
+        %tmp1 = mul i64 %x, %x
+        %tmp2 = mul i64 %x, 3
+        %tmp3 = add i64 %tmp1, %tmp2
+        %tmp4 = add i64 %tmp3, 4
+        ret i64 %tmp4
+; CHECK-LABEL: @test9(
+; CHECK-NEXT: add i64 %x, 3
+; CHECK-NEXT: mul i64 %tmp21, %x
+; CHECK-NEXT: add i64 %tmp3, 4
+; CHECK-NEXT: ret i64
+}
+
+


### PR DESCRIPTION
Improve llvm optimizer on perfect square trinomial with constant 1.
The original optimizer can do x*x + 2*x + 1 -> x(x+2) +1, I improved it into x*x + 2*x + 1 -> (x+1)*(x+1).
The implementation has test case in llvm/tests/perfect_square_trinomial_const.ll, which contains 6 positive tests and 3 negative tests.