### PR TITLE
Cs6475 assignment2 - fifth bit zero check optimization - updated

### DIFF
--- a/llvm/test/Transforms/InstCombine/sinamps-fifthbit-check-neg.ll
+++ b/llvm/test/Transforms/InstCombine/sinamps-fifthbit-check-neg.ll
@@ -1,0 +1,19 @@
+; RUN: opt < %s -passes=instcombine -S | FileCheck %s
+
+; Should not be optimized as the pattern does not match.
+define i1 @test_negative(i16 %t) {
+; CHECK-LABEL: @test_negative(
+; CHECK-NEXT:    [[A:%.*]] = lshr i16 [[T:%.*]], 3
+; CHECK-NEXT:    [[B:%.*]] = and i16 [[A]], 1
+; CHECK-NEXT:    [[D:%.*]] = sub nsw i16 0, [[A]]
+; CHECK-NEXT:    [[E:%.*]] = and i16 [[B]], [[D]]
+; CHECK-NEXT:    [[F:%.*]] = icmp ne i16 [[E]], 0
+; CHECK-NEXT:    ret i1 [[F]]
+;
+  %a = lshr i16 %t, 3
+  %b = and i16 %a, 1
+  %d = sub nsw i16 0, %a
+  %e = and i16 %b, %d
+  %f = icmp ne i16 %e, 0
+  ret i1 %f
+}

--- a/llvm/test/Transforms/InstCombine/sinamps-fifthbit-check-pos.ll
+++ b/llvm/test/Transforms/InstCombine/sinamps-fifthbit-check-pos.ll
@@ -1,0 +1,16 @@
+; RUN: opt < %s -passes=instcombine -S | FileCheck %s
+
+; Should be optimized to only an and and icmp ne.
+define i1 @test_positive(i16 %t) {
+; CHECK-LABEL: @test_positive(
+; CHECK-NEXT:    [[A2:%.*]] = and i16 [[T:%.*]], 16
+; CHECK-NEXT:    [[F:%.*]] = icmp ne i16 [[A2]], 0
+; CHECK-NEXT:    ret i1 [[F]]
+;
+  %a = lshr i16 %t, 4
+  %b = and i16 %a, 1
+  %d = sub nsw i16 0, %a
+  %e = and i16 %b, %d
+  %f = icmp ne i16 %e, 0
+  ret i1 %f
+}


### PR DESCRIPTION
Sina Mahdipour Saravani

Reviews applied.
Optimization implemented for this refinement:
https://alive2.llvm.org/ce/z/PJiiAe
(checking is fifth bit is zero)

Two test files added in llvm/test with filenames starting with "sinamps-*".
ninja check has been run and both tests are passed and have increased the total number of tests.