### PR TITLE
Jacob Knowlton - Assignment 2 Optimization

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5066,8 +5066,57 @@ Instruction* cs6475_optimizer(Instruction *I) {
     }
   }
   // END JOHN REGEHR
+  
+  // BEGIN JACOB KNOWLTON
+  Value *X1 = nullptr;
+  Value *X2 = nullptr;
+  // >= case
+  ICmpInst::Predicate Pred1 = ICmpInst::ICMP_SGE; 
+  if (match(I, m_ICmp(Pred1, m_Value(X), m_Value(Y)))) {
+    if (match(Y, m_ConstantInt(C))) {
+      if (C->isZero()) {
+        if (match(X, m_Mul(m_Value(X1), m_Value(X2)))) {
+          auto Mul1 = dyn_cast<BinaryOperator>(X);
+          if (Mul1->hasNoSignedWrap()) {
+            if (match(X1, m_Mul(m_Specific(X2), m_ConstantInt(C))) || match(X1, m_Shl(m_Specific(X2), m_ConstantInt(C)))) {
+              auto Mul2 = dyn_cast<BinaryOperator>(X1);
+              if (Mul2->hasNoSignedWrap()) {
+                if (C->getUniqueInteger().isNonNegative()) {
+                  ICmpInst::Predicate Pred3 = ICmpInst::ICMP_EQ; 
+                  return new ICmpInst(Pred3, ConstantInt::getTrue(I->getContext()), ConstantInt::getTrue(I->getContext()));
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  // > case
+  ICmpInst::Predicate Pred2 = ICmpInst::ICMP_SGT; 
+  if (match(I, m_ICmp(Pred2, m_Value(X), m_Value(Y)))) {
+    if (match(Y, m_ConstantInt(C))) {
+      if (C->isMinusOne()) {
+        if (match(X, m_Mul(m_Value(X1), m_Value(X2)))) {
+          auto Mul1 = dyn_cast<BinaryOperator>(X);
+          if (Mul1->hasNoSignedWrap()) {
+            if (match(X1, m_Mul(m_Specific(X2), m_ConstantInt(C))) || match(X1, m_Shl(m_Specific(X2), m_ConstantInt(C)))) {
+              auto Mul2 = dyn_cast<BinaryOperator>(X1);
+              if (Mul2->hasNoSignedWrap()) {
+                if (C->getUniqueInteger().isNonNegative()) {
+                  ICmpInst::Predicate Pred3 = ICmpInst::ICMP_EQ; 
+                  return new ICmpInst(Pred3, ConstantInt::getTrue(I->getContext()), ConstantInt::getTrue(I->getContext()));
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  // END JACOB KNOWLTON
 
- return nullptr;
+return nullptr;
 }
 
 bool InstCombinerImpl::run() {

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5118,7 +5118,7 @@ Instruction* cs6475_optimizer(Instruction *I) {
   }
   // END JACOB KNOWLTON
 
-return nullptr;
+ return nullptr;
 }
 
 bool InstCombinerImpl::run() {

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5082,6 +5082,7 @@ Instruction* cs6475_optimizer(Instruction *I) {
               auto Mul2 = dyn_cast<BinaryOperator>(X1);
               if (Mul2->hasNoSignedWrap()) {
                 if (C->getUniqueInteger().isNonNegative()) {
+                  log_optzn("Jacob Knowlton");
                   ICmpInst::Predicate Pred3 = ICmpInst::ICMP_EQ; 
                   return new ICmpInst(Pred3, ConstantInt::getTrue(I->getContext()), ConstantInt::getTrue(I->getContext()));
                 }
@@ -5104,6 +5105,7 @@ Instruction* cs6475_optimizer(Instruction *I) {
               auto Mul2 = dyn_cast<BinaryOperator>(X1);
               if (Mul2->hasNoSignedWrap()) {
                 if (C->getUniqueInteger().isNonNegative()) {
+                  log_optzn("Jacob Knowlton");
                   ICmpInst::Predicate Pred3 = ICmpInst::ICMP_EQ; 
                   return new ICmpInst(Pred3, ConstantInt::getTrue(I->getContext()), ConstantInt::getTrue(I->getContext()));
                 }

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5068,23 +5068,25 @@ Instruction* cs6475_optimizer(Instruction *I) {
   // END JOHN REGEHR
   
   // BEGIN JACOB KNOWLTON
-  Value *X1 = nullptr;
-  Value *X2 = nullptr;
-  // >= case
-  ICmpInst::Predicate Pred1 = ICmpInst::ICMP_SGE; 
-  if (match(I, m_ICmp(Pred1, m_Value(X), m_Value(Y)))) {
-    if (match(Y, m_ConstantInt(C))) {
-      if (C->isZero()) {
-        if (match(X, m_Mul(m_Value(X1), m_Value(X2)))) {
-          auto Mul1 = dyn_cast<BinaryOperator>(X);
-          if (Mul1->hasNoSignedWrap()) {
-            if (match(X1, m_Mul(m_Specific(X2), m_ConstantInt(C))) || match(X1, m_Shl(m_Specific(X2), m_ConstantInt(C)))) {
-              auto Mul2 = dyn_cast<BinaryOperator>(X1);
-              if (Mul2->hasNoSignedWrap()) {
-                if (C->getUniqueInteger().isNonNegative()) {
-                  log_optzn("Jacob Knowlton");
-                  ICmpInst::Predicate Pred3 = ICmpInst::ICMP_EQ; 
-                  return new ICmpInst(Pred3, ConstantInt::getTrue(I->getContext()), ConstantInt::getTrue(I->getContext()));
+  {
+    Value *X1 = nullptr;
+    Value *X2 = nullptr;
+    // >= case
+    ICmpInst::Predicate Pred1 = ICmpInst::ICMP_SGE; 
+    if (match(I, m_ICmp(Pred1, m_Value(X), m_Value(Y)))) {
+      if (match(Y, m_ConstantInt(C))) {
+        if (C->isZero()) {
+          if (match(X, m_Mul(m_Value(X1), m_Value(X2)))) {
+            auto Mul1 = dyn_cast<BinaryOperator>(X);
+            if (Mul1->hasNoSignedWrap()) {
+              if (match(X1, m_Mul(m_Specific(X2), m_ConstantInt(C))) || match(X1, m_Shl(m_Specific(X2), m_ConstantInt(C)))) {
+                auto Mul2 = dyn_cast<BinaryOperator>(X1);
+                if (Mul2->hasNoSignedWrap()) {
+                  if (C->getUniqueInteger().isNonNegative()) {
+                    log_optzn("Jacob Knowlton");
+                    ICmpInst::Predicate Pred3 = ICmpInst::ICMP_EQ; 
+                    return new ICmpInst(Pred3, ConstantInt::getTrue(I->getContext()), ConstantInt::getTrue(I->getContext()));
+                  }
                 }
               }
             }
@@ -5092,22 +5094,22 @@ Instruction* cs6475_optimizer(Instruction *I) {
         }
       }
     }
-  }
-  // > case
-  ICmpInst::Predicate Pred2 = ICmpInst::ICMP_SGT; 
-  if (match(I, m_ICmp(Pred2, m_Value(X), m_Value(Y)))) {
-    if (match(Y, m_ConstantInt(C))) {
-      if (C->isMinusOne()) {
-        if (match(X, m_Mul(m_Value(X1), m_Value(X2)))) {
-          auto Mul1 = dyn_cast<BinaryOperator>(X);
-          if (Mul1->hasNoSignedWrap()) {
-            if (match(X1, m_Mul(m_Specific(X2), m_ConstantInt(C))) || match(X1, m_Shl(m_Specific(X2), m_ConstantInt(C)))) {
-              auto Mul2 = dyn_cast<BinaryOperator>(X1);
-              if (Mul2->hasNoSignedWrap()) {
-                if (C->getUniqueInteger().isNonNegative()) {
-                  log_optzn("Jacob Knowlton");
-                  ICmpInst::Predicate Pred3 = ICmpInst::ICMP_EQ; 
-                  return new ICmpInst(Pred3, ConstantInt::getTrue(I->getContext()), ConstantInt::getTrue(I->getContext()));
+    // > case
+    ICmpInst::Predicate Pred2 = ICmpInst::ICMP_SGT; 
+    if (match(I, m_ICmp(Pred2, m_Value(X), m_Value(Y)))) {
+      if (match(Y, m_ConstantInt(C))) {
+        if (C->isMinusOne()) {
+          if (match(X, m_Mul(m_Value(X1), m_Value(X2)))) {
+            auto Mul1 = dyn_cast<BinaryOperator>(X);
+            if (Mul1->hasNoSignedWrap()) {
+              if (match(X1, m_Mul(m_Specific(X2), m_ConstantInt(C))) || match(X1, m_Shl(m_Specific(X2), m_ConstantInt(C)))) {
+                auto Mul2 = dyn_cast<BinaryOperator>(X1);
+                if (Mul2->hasNoSignedWrap()) {
+                  if (C->getUniqueInteger().isNonNegative()) {
+                    log_optzn("Jacob Knowlton");
+                    ICmpInst::Predicate Pred3 = ICmpInst::ICMP_EQ; 
+                    return new ICmpInst(Pred3, ConstantInt::getTrue(I->getContext()), ConstantInt::getTrue(I->getContext()));
+                  }
                 }
               }
             }

--- a/llvm/test/Transforms/InstCombine/mul-const-icmp.ll
+++ b/llvm/test/Transforms/InstCombine/mul-const-icmp.ll
@@ -1,0 +1,36 @@
+; RUN: opt < %s -passes=instcombine -S | FileCheck %s
+
+; Test 1: Simple Case (Optimization Applied)
+define i1 @test1(i16 %x) {
+  %mul1 = mul nsw i16 %x, 3 ; Positive constant
+  %mul2 = mul nsw i16 %mul1, %x
+  %cmp = icmp sge i16 %mul2, 0
+  ret i1 %cmp
+}
+
+; CHECK-LABEL: @test1(
+; CHECK-NEXT:    ret i1 true
+
+; Test 2: No `nsw` Flag (Optimization Not Applied)
+define i1 @test2(i16 %x) {
+  %mul1 = mul i16 %x, 3 ; No 'nsw' flag
+  %mul2 = mul i16 %mul1, %x
+  %cmp = icmp sge i16 %mul2, 0
+  ret i1 %cmp
+}
+
+; CHECK-LABEL: @test2(
+; CHECK-NOT:    ret i1 true 
+; CHECK: ret i1 %cmp
+
+; Test 3: Non-Positive Constant (Optimization Not Applied)
+define i1 @test3(i16 %x) {
+  %mul1 = mul nsw i16 %x, -5 ; Non-positive constant
+  %mul2 = mul nsw i16 %mul1, %x
+  %cmp = icmp sge i16 %mul2, 0
+  ret i1 %cmp
+}
+
+; CHECK-LABEL: @test3(
+; CHECK-NOT:    ret i1 true
+; CHECK: ret i1 %cmp


### PR DESCRIPTION
Wrapped optimization in a scope to prevent leaking local variables to other optimizations.

Original PR:
> This pull request adds a small optimization to LLVM's InstCombine pass. It recognizes a pattern where a value is multiplied by a positive constant, then multiplied by itself again, and finally checked if it is non-negative (using icmp sge against 0, or icmp sgt against -1). Since the result of this computation is always non-negative, the comparison is replaced with a trivial compare, which then gets optimized to the constant true.
> 
> 3 regression tests have been added to verify the optimization's behavior (one positive and two negative). All unit and regression tests that were previously passing still pass as well.
> 
> Compiler Explorer link showing that LLVM didn't implement this optimization: https://gcc.godbolt.org/z/adWfT5PxK
> Alive2 link showing that it is a valid refinement: https://alive2.llvm.org/ce/z/h_sJ6n