### PR TITLE
Cs6475 assignment2 - fifth bit zero check optimization - updated - removed merge conflict

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5713,6 +5713,51 @@ Instruction* cs6475_optimizer(Instruction *I, InstCombinerImpl &IC, LazyValueInf
   }
   // END LEE WEI
 
+  // BEGIN SINA MAHDIPOUR SARAVANI
+  {
+    // Optimization for checking if fifth bit is zero
+    Value *X = nullptr;
+    Value *ICmpLeftOperand = nullptr, *And2RightOperand = nullptr, *And2LeftOperand = nullptr, *And1LeftOperand = nullptr;
+    ICmpInst::Predicate ICmpPredicate;
+    ConstantInt *ZeroConstant2 = nullptr;
+    ConstantInt *ZeroConstant = nullptr;
+    ConstantInt *OneConstant = nullptr;
+    ConstantInt *FourConstant = nullptr;
+
+    if (
+          match(I, m_ICmp(ICmpPredicate, m_Value(ICmpLeftOperand), m_ConstantInt(ZeroConstant2))) &&
+            (ZeroConstant2->getValue() == 0) &&
+          match(ICmpLeftOperand, m_And(m_Value(And2LeftOperand), m_Value(And2RightOperand))) &&
+          match(And2RightOperand, m_Sub(m_ConstantInt(ZeroConstant), m_Value(And1LeftOperand))) &&
+            (ZeroConstant->getValue() == 0) &&
+          match(And2LeftOperand, m_And(m_Specific(And1LeftOperand), m_ConstantInt(OneConstant))) &&
+            (OneConstant->getValue() == 1) &&
+          match(And1LeftOperand, m_LShr(m_Value(X), m_ConstantInt(FourConstant))) &&
+            (FourConstant->getValue() == 4)
+        ) {
+
+      // We have matched the required pattern
+      // Create the two replacement instructions
+      IRBuilder<> Builder(I);
+      Value *NewAnd = Builder.CreateAnd(X, ConstantInt::get(X->getType(), 16));
+      Value *NewICmp = Builder.CreateICmpNE(NewAnd, ConstantInt::get(X->getType(), 0));
+
+      // Replace all uses of the original instruction with the new instruction
+      I->replaceAllUsesWith(NewICmp);
+      // NewICmp->takeName(I);
+      // Erase the old instructions
+      I->eraseFromParent();
+      cast<Instruction>(ICmpLeftOperand)->eraseFromParent();
+      cast<Instruction>(And2RightOperand)->eraseFromParent();
+      cast<Instruction>(And2LeftOperand)->eraseFromParent();
+      cast<Instruction>(And1LeftOperand)->eraseFromParent();
+
+      log_optzn("\nSina Saravani\n");
+      return nullptr;  // Since we've deleted the original instruction
+    }
+  }
+  // END SINA MAHDIPOUR SARAVANI
+
   return nullptr;
 }
 

--- a/llvm/test/Transforms/InstCombine/sinamps-fifthbit-check-neg.ll
+++ b/llvm/test/Transforms/InstCombine/sinamps-fifthbit-check-neg.ll
@@ -1,0 +1,19 @@
+; RUN: opt < %s -passes=instcombine -S | FileCheck %s
+
+; Should not be optimized as the pattern does not match.
+define i1 @test_negative(i16 %t) {
+; CHECK-LABEL: @test_negative(
+; CHECK-NEXT:    [[A:%.*]] = lshr i16 [[T:%.*]], 3
+; CHECK-NEXT:    [[B:%.*]] = and i16 [[A]], 1
+; CHECK-NEXT:    [[D:%.*]] = sub nsw i16 0, [[A]]
+; CHECK-NEXT:    [[E:%.*]] = and i16 [[B]], [[D]]
+; CHECK-NEXT:    [[F:%.*]] = icmp ne i16 [[E]], 0
+; CHECK-NEXT:    ret i1 [[F]]
+;
+  %a = lshr i16 %t, 3
+  %b = and i16 %a, 1
+  %d = sub nsw i16 0, %a
+  %e = and i16 %b, %d
+  %f = icmp ne i16 %e, 0
+  ret i1 %f
+}

--- a/llvm/test/Transforms/InstCombine/sinamps-fifthbit-check-pos.ll
+++ b/llvm/test/Transforms/InstCombine/sinamps-fifthbit-check-pos.ll
@@ -1,0 +1,16 @@
+; RUN: opt < %s -passes=instcombine -S | FileCheck %s
+
+; Should be optimized to only an and and icmp ne.
+define i1 @test_positive(i16 %t) {
+; CHECK-LABEL: @test_positive(
+; CHECK-NEXT:    [[A2:%.*]] = and i16 [[T:%.*]], 16
+; CHECK-NEXT:    [[F:%.*]] = icmp ne i16 [[A2]], 0
+; CHECK-NEXT:    ret i1 [[F]]
+;
+  %a = lshr i16 %t, 4
+  %b = and i16 %a, 1
+  %d = sub nsw i16 0, %a
+  %e = and i16 %b, %d
+  %f = icmp ne i16 %e, 0
+  ret i1 %f
+}


### PR DESCRIPTION
Sina Mahdipour Saravani

Reviews applied.
Optimization implemented for this refinement:
https://alive2.llvm.org/ce/z/PJiiAe
(checking if fifth bit is zero)

Two test files added in llvm/test with filenames starting with "sinamps-*".
ninja check has been run and both tests are passed and have increased the total number of tests.