### PR TITLE
Kincaid Savoie - assignment 2

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -58,6 +58,7 @@
 #include "llvm/Analysis/Utils/Local.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/Analysis/VectorUtils.h"
+#include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/CFG.h"
 #include "llvm/IR/Constant.h"
@@ -5056,7 +5057,7 @@ void log_optzn(const std::string &Name) {
 void cs6475_debug(std::string DbgString) {
   // set this to "false" to suppress debug output, before running "ninja test"
   // set this to "true" to see debug output, to help you understand your transformation
-  if (true)
+  if (false)
     dbgs() << DbgString;
 }
 
@@ -5206,6 +5207,55 @@ Instruction *cs6475_optimizer_tavakkoli(Instruction *I) {
 
   return nullptr;
 }
+
+// BEGIN KINCAID SAVOIE
+static Instruction* ksavoie_optimization(Instruction* I) {
+  // Attempt to match, bailing out if any invariant doesn't hold
+
+  Value* THREE = nullptr;
+  Value* FOUR = nullptr;
+  if(!match(I, m_Or(m_Value(THREE), m_Value(FOUR))))
+    return nullptr;
+
+  Value* ONE = nullptr;
+  Value* TWO = nullptr;
+  if(!match(THREE, m_And(m_Value(ONE), m_Value(TWO))))
+    return nullptr;
+
+  Value* X = nullptr;
+  ConstantInt* C0 = nullptr;
+  if(!match(ONE, m_And(m_Value(X), m_ConstantInt(C0))))
+    return nullptr;
+
+  if(C0->getUniqueInteger().getSExtValue() != 1)
+    return nullptr;
+
+  Value* Y = nullptr;
+  ConstantInt* C1 = nullptr;
+  if(!match(TWO, m_Xor(m_Value(Y), m_ConstantInt(C1))))
+    return nullptr;
+
+  if(C1->getUniqueInteger().getSExtValue() != -1)
+    return nullptr;
+
+  ConstantInt* C2 = nullptr;
+  if(!match(FOUR, m_And(m_Specific(X), m_ConstantInt(C2))))
+    return nullptr;
+
+  if(C2->getUniqueInteger().getSExtValue() != -2)
+    return nullptr;
+
+  // Match successful, create new instruction
+
+  IRBuilder<> Builder(I);
+  Value* V0 = Builder.CreateAnd(Y, C0);
+  Value* V1 = Builder.CreateXor(V0, C1);
+
+	log_optzn("Kincaid Savoie");
+
+	return BinaryOperator::CreateAnd(V1, X);
+}
+// END KINCAID SAVOIE
 
 Instruction* cs6475_optimizer(Instruction *I, InstCombinerImpl &IC, LazyValueInfo *LVI) {
   cs6475_debug("\nCS 6475 matcher: running now\n");
@@ -5712,6 +5762,11 @@ Instruction* cs6475_optimizer(Instruction *I, InstCombinerImpl &IC, LazyValueInf
     }
   }
   // END LEE WEI
+
+  // BEGIN KINCAID SAVOIE
+  if(Instruction* NewI = ksavoie_optimization(I))
+    return NewI;
+  // END KINCAID SAVOIE
 
   return nullptr;
 }

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -58,7 +58,6 @@
 #include "llvm/Analysis/Utils/Local.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/Analysis/VectorUtils.h"
-#include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/CFG.h"
 #include "llvm/IR/Constant.h"
@@ -5057,7 +5056,7 @@ void log_optzn(const std::string &Name) {
 void cs6475_debug(std::string DbgString) {
   // set this to "false" to suppress debug output, before running "ninja test"
   // set this to "true" to see debug output, to help you understand your transformation
-  if (false)
+  if (true)
     dbgs() << DbgString;
 }
 

--- a/llvm/test/Transforms/InstCombine/ksavoie-assignment-2.ll
+++ b/llvm/test/Transforms/InstCombine/ksavoie-assignment-2.ll
@@ -1,0 +1,37 @@
+; RUN: opt < %s -passes='instcombine<no-verify-fixpoint>' -S | FileCheck %s
+
+define noundef i32 @reduce-case(i32 noundef %x, i32 noundef %y) unnamed_addr #0 {
+; CHECK-LABEL: @reduce-case(
+; CHECK-NEXT:    [[A:%.*]] = and i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[B:%.*]] = xor i32 [[A:%.*]], -1
+; CHECK-NEXT:    [[C:%.*]] = and i32 [[B:%.*]], [[X:%.*]]
+; CHECK-NEXT:    ret i32 [[C:%.*]]
+
+  %1 = and i32 %x, 1
+  %2 = xor i32 %y, -1
+  %3 = and i32 %1, %2
+  %4 = and i32 %x, -2
+  %5 = or disjoint i32 %3, %4 
+
+  ret i32 %5
+}
+
+define noundef i32 @reduce-case-fail-diff-const(i32 noundef %x, i32 noundef %y) unnamed_addr #0 {
+; CHECK-LABEL: @reduce-case-fail-diff-const(
+; CHECK-NEXT:    [[A:%.*]] = and i32 [[X:%.*]], 255
+; CHECK-NEXT:    [[B:%.*]] = xor i32 [[Y:%.*]], -1
+; CHECK-NEXT:    [[C:%.*]] = and i32 [[A:%.*]], [[B:%.*]]
+; CHECK-NEXT:    [[D:%.*]] = and i32 [[X:%.*]], -2
+; CHECK-NEXT:    [[E:%.*]] = or disjoint i32 [[C:%.*]], [[D:%.*]] 
+; CHECK-NEXT:    ret i32 [[E:%.*]]
+
+  %1 = and i32 %x, 255
+  %2 = xor i32 %y, -1
+  %3 = and i32 %1, %2
+  %4 = and i32 %x, -2
+  %5 = or disjoint i32 %3, %4 
+
+  ret i32 %5
+}
+
+attributes #0 = { mustprogress nofree norecurse nosync nounwind nonlazybind willreturn memory(none) uwtable "probe-stack"="inline-asm" "target-cpu"="x86-64" }


### PR DESCRIPTION
_Rebased against ToT_

Implement the optimization described in this Github issue: https://github.com/llvm/llvm-project/issues/83699

Here is the refinement:

```
define noundef i32 @src(i32 noundef %prev_value, i32 noundef %new_value) unnamed_addr {
start:
  %0 = and i32 %prev_value, 1
  %new_bit = and i32 %new_value, 1
  %_5 = xor i32 %new_bit, -1
  %1 = and i32 %0, %_5
  %_6 = and i32 %prev_value, -2
  %_0 = or disjoint i32 %1, %_6
  ret i32 %_0
}

define noundef i32 @tgt(i32 noundef %prev_value, i32 noundef %new_value) unnamed_addr {
start:
  %_4 = and i32 %new_value, 1
  %_3 = xor i32 %_4, -1
  %_0 = and i32 %_3, %prev_value
  ret i32 %_0
}
```
Here is a link to compiler explorer showing that the optimization hasn't been implemented: https://godbolt.org/z/ofnfGrYx5

And an Alive2 link showing that the transformation is a refinement: https://alive2.llvm.org/ce/z/GQeQTS

A positive and negative test have been added in test/Transforms/InstCombine/ksavoie-assignment-2.ll